### PR TITLE
Add LiteBag_AddUpdateEvent to global

### DIFF
--- a/Panel.lua
+++ b/Panel.lua
@@ -461,6 +461,8 @@ function LB.AddUpdateEvent(e)
     PluginUpdateEvents[e] = true
 end
 
+_G.LiteBag_AddUpdateEvent = LB.AddUpdateEvent
+
 function LiteBagPanel_Update(self)
     LiteBagPanel_UpdateBagSlotCounts(self)
     LiteBagPanel_UpdateSizeAndLayout(self)


### PR DESCRIPTION
README.md mentions that addons can use LiteBag_AddUpdateEvent,
however it's currently not in global. This causes some
third-party addons like Caerdon Wardrobe to error on startup.