### PR TITLE
Adding option to reduce size of BoA / BoE text

### DIFF
--- a/Options.lua
+++ b/Options.lua
@@ -41,6 +41,7 @@ local defaults = {
         },
         showEquipmentSets = false,
         showBindsOn = false,
+        smallerBindsOnText = false,
         hideBlizzardBagButtons = false,
         allowHideBagIDs = { [Enum.BagIndex.ReagentBag] = true },
         hideBagIDs = { },

--- a/Plugin_BindsOn/BindsOn.lua
+++ b/Plugin_BindsOn/BindsOn.lua
@@ -87,8 +87,10 @@ local BindTextsByButton = {}
 local function Update(button)
     if BindTextsByButton[button] == nil then
         BindTextsByButton[button] = button:CreateFontString(nil, "ARTWORK", "GameFontNormalOutline")
-        BindTextsByButton[button]:SetFont("Fonts\\FRIZQT__.TTF", 9, "OUTLINE")
-        BindTextsByButton[button]:SetPoint("TOP", button, "TOP", 0, -2)
+        if LB.GetGlobalOption("smallerBindsOnText") then
+            BindTextsByButton[button]:SetFont("Fonts\\FRIZQT__.TTF", 9, "OUTLINE")
+        end
+        BindTextsByButton[button]:SetPoint("TOPLEFT", button, "TOPLEFT", 2, -2)
     end
 
     if LB.GetGlobalOption("showBindsOn") then

--- a/Plugin_BindsOn/BindsOn.lua
+++ b/Plugin_BindsOn/BindsOn.lua
@@ -87,6 +87,7 @@ local BindTextsByButton = {}
 local function Update(button)
     if BindTextsByButton[button] == nil then
         BindTextsByButton[button] = button:CreateFontString(nil, "ARTWORK", "GameFontNormalOutline")
+        BindTextsByButton[button]:SetFont("Fonts\\FRIZQT__.TTF", 9, "OUTLINE")
         BindTextsByButton[button]:SetPoint("TOP", button, "TOP", 0, -2)
     end
 

--- a/UI/Options.lua
+++ b/UI/Options.lua
@@ -158,6 +158,14 @@ local options = {
             get = GlobalGetter,
             set = GlobalSetter,
         },
+        smallerBindsOnText = {
+            type = "toggle",
+            name = L["Reduce the font size for BoA and BoE items. (Requires Reload)"],
+            order = order(),
+            width = "full",
+            get = GlobalGetter,
+            set = GlobalSetter,
+        },
         showEquipmentSets = {
             type = "toggle",
             name = L["Display equipment set membership icons."],


### PR DESCRIPTION
I found that the default text for BoA / BoE is just too big. It covers too much of the icon for what little information it actual requires.  I've added an option for users to reduce it to a smaller size.

Before Change: 
![image](https://github.com/user-attachments/assets/01198daa-c222-478d-9416-fa0dc82acff1)

After Change:
![image](https://github.com/user-attachments/assets/041d6675-8cfb-4da4-9b07-c72fe814d3e5)

Setting:
![image](https://github.com/user-attachments/assets/ea8278a4-e328-488e-9fd3-4613bc331adc)
